### PR TITLE
Improve finder method to prevent PG::Syntax errors if array is empty

### DIFF
--- a/lib/activerecord/pg_array.rb
+++ b/lib/activerecord/pg_array.rb
@@ -50,7 +50,7 @@ module ActiveRecord
           define_method :"add_#{friendly_attr_singular}!" do |obj|
             obj = obj_convert[obj]
             atr_will_change[self] # seems strange that calling this is needed
-            
+
             # There are two external issues that block atomic updates to one attribute.
             # 1. ActiveRecord update_attribute actually updates all attributes that are dirty! This surprised me.
             # 2. update_column doesn't work on pg arrays for rails < 4.0.4 (which is not yet released)
@@ -101,7 +101,7 @@ module ActiveRecord
             self.send :"remove_#{friendly_attr_plural}", *objs
             self.save!
           end
-          
+
           # define basic relational lookup methods
           # example:
           #   Given wolf_ids is the attribute
@@ -114,7 +114,10 @@ module ActiveRecord
 
                 # it might be better to define a scope instead
                 define_method friendly_attr_plural.to_sym do
-                  klass.where(id: [atr[self]])
+                  # passing an empty array to a SQL `IN` clause throws a PG::SyntaxError;
+                  # check to see if there are any items in the array and
+                  # send back any empty array if empty...
+                  self.send(attr_name).empty? ? [] : klass.where(id: [atr[self]])
                 end
               rescue NameError
               end

--- a/spec/lib/pg_array_spec.rb
+++ b/spec/lib/pg_array_spec.rb
@@ -18,6 +18,7 @@ end
 
 describe WolfTracker do
   let(:wolf_tracker)  { WolfTracker.create(name: 'Wolfram') }
+  let(:empty_wolf_tracker)  { WolfTracker.create }
   let(:wolfy) { Wolf.create(name: 'Wolfy') }
   let(:son_of_wolfy) { Wolf.create(name: 'Son of Wolfy') }
   let(:wolfia) { Wolf.create(name: 'Wolfia') }
@@ -177,7 +178,7 @@ describe WolfTracker do
 
   describe "finder methods" do
     before do
-      wolf_tracker.add_wolves(wolfy, son_of_wolfy) 
+      wolf_tracker.add_wolves(wolfy, son_of_wolfy)
       wolf_tracker.save!
     end
 
@@ -186,6 +187,10 @@ describe WolfTracker do
 
     it "should have a wolves finder method and return a wolf" do
       expect(wolf_tracker.wolves).to eq [wolfy, son_of_wolfy]
+    end
+
+    it "should have a finder method and return an empty array if there aren't any wolves" do
+      expect(empty_wolf_tracker.wolves).to be_empty
     end
 
   end # scopes


### PR DESCRIPTION
Noticed that an empty array was throwing an SQL syntax error due to the empty 'IN' clause of the SQL being generated. Added a check to see if there are items in the array before the SQL is executed. This implementation is based on README, where default value for the column is [].

Test method included...
